### PR TITLE
Fix target name and add poetry installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 init:
-	poetry install
+	python -m pip install poetry
+	poetry install --no-root
 
 test:
 	poetry run pytest -sv homework/tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # aaa-async-2023-public
 
+## Требования
+
+- Python 3.12
+
 ## Настройка окружения
 
 `make init`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # aaa-async-2023-public
 
 ## Настройка окружения
-`make install`
+
+`make init`
 
 ## Запуск тестов
+
 `make test`


### PR DESCRIPTION
1. Изменил таргет в `Makefile`, чтобы он заработал
2. Добавил установку `poetry`, так как по умолчанию он не установлен
3. Добавил флаг `--no-root` к `poetry`, так как не требуется установка проекта (иначе он ругается)
4. Добавил явную версию питона, иначе зависимости не установятся

Классная домашка 🤗